### PR TITLE
Minor accessibility fixes

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -497,7 +497,7 @@ address {
 
   a {
     font-size: 0.8rem;
-    color: #ccc;
+    color: #6e6e6e;
     text-decoration: none;
     text-transform: uppercase;
     transition: color 0.2 ease-out;
@@ -596,6 +596,7 @@ address {
   background: #eee;
   font-style: oblique;
   font-size: 0.9rem;
+  font-weight: normal;
 }
 
 .footer h6 {

--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -18,7 +18,7 @@ export default class Template extends React.Component {
           <Container className="primary-navigation" >
             <div className="logo-container">
               <Link to={prefixLink('/')} >
-                <img className="logo" src="/images/javascriptmn.png" />
+                <img className="logo" src="/images/javascriptmn.png" alt="Logo for JavaScriptMN" />
               </Link>
             </div>
             <div className="secondary-nav">

--- a/pages/images/sponsors/logo-icf-olson.svg
+++ b/pages/images/sponsors/logo-icf-olson.svg
@@ -2,6 +2,7 @@
 <!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 123.4 35.7" style="enable-background:new 0 0 123.4 35.7;" xml:space="preserve">
+	 <title>ICF Olson Logo</title>
 <style type="text/css">
 	.st0{fill:#000000;}
 </style>
@@ -11,18 +12,18 @@
 			<g>
 				<g>
 					<g>
-						<polygon class="st0" points="39.9,27.9 43.6,27.9 43.6,31.3 39.9,31.3 39.9,35.3 35.8,35.3 35.8,22.9 44.2,22.9 44.2,26.4 
+						<polygon class="st0" points="39.9,27.9 43.6,27.9 43.6,31.3 39.9,31.3 39.9,35.3 35.8,35.3 35.8,22.9 44.2,22.9 44.2,26.4
 							39.9,26.4 						"/>
 						<rect x="15.6" y="22.9" class="st0" width="4.1" height="12.4"/>
 					</g>
 					<g>
-						
+
 							<rect x="3.4" y="23.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -15.3975 14.2803)" class="st0" width="12.4" height="3.6"/>
 						<rect y="16.1" class="st0" width="12.4" height="3.1"/>
-						
+
 							<rect x="8.2" y="3.4" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -3.9516 9.5401)" class="st0" width="2.6" height="12.4"/>
 						<rect x="16.6" class="st0" width="2.1" height="12.4"/>
-						
+
 							<rect x="19.5" y="8.7" transform="matrix(0.7071 -0.7071 0.7071 0.7071 0.7896 20.9863)" class="st0" width="12.4" height="1.6"/>
 						<rect x="22.9" y="17.1" class="st0" width="12.4" height="1.1"/>
 					</g>
@@ -43,7 +44,7 @@
 		<path class="st0" d="M95.2,29.1L95.2,29.1c0-3.6,2.9-6.5,6.7-6.5c3.8,0,6.7,2.8,6.7,6.4v0c0,3.6-2.9,6.4-6.7,6.4
 			C98,35.5,95.2,32.7,95.2,29.1 M105,29.1L105,29.1c0-1.8-1.3-3.4-3.2-3.4c-1.9,0-3.1,1.5-3.1,3.3v0c0,1.8,1.3,3.3,3.2,3.3
 			C103.8,32.4,105,30.9,105,29.1"/>
-		<polygon class="st0" points="111.7,22.9 114.9,22.9 120,29.4 120,22.9 123.4,22.9 123.4,35.3 120.4,35.3 115.1,28.5 115.1,35.3 
+		<polygon class="st0" points="111.7,22.9 114.9,22.9 120,29.4 120,22.9 123.4,22.9 123.4,35.3 120.4,35.3 115.1,28.5 115.1,35.3
 			111.7,35.3 		"/>
 	</g>
 </g>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -39,7 +39,7 @@ class index extends React.Component {
 
             <div className='sponsor-container-row'>
               <div className='sponsor'>
-                <img src={'images/sponsors/logo-icf-olson.svg'} />
+                <img src={'images/sponsors/logo-icf-olson.svg'} alt='Logo for ICF Olson' />
               </div>
             </div>
 
@@ -70,7 +70,7 @@ class index extends React.Component {
 
       <div className='secondary-content tilt-right'>
         <div className='column'>
-          <img width={650} src={'images/speak.jpeg'} />
+          <img width={650} src={'images/speak.jpeg'} alt='A panorama of a JavaScriptMN event' />
         </div>
         <div className='column info-column'>
           <h2 className='secondary-content-header'>Speaking</h2>


### PR DESCRIPTION
Ran Chrome's [Lightbox](https://developers.google.com/web/tools/lighthouse/) audits on the site while killing time at the last event and noticed a couple of super quick fixes that I could make:

- Lack of [alt text](https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse) on homepage logos
- [Insufficient contrast](https://dequeuniversity.com/rules/axe/2.2/color-contrast?application=lighthouse) between the footer nav anchor colors and the background

The latter fix may deserve broader style updates as the footer nav anchor color is now nearly the same as each group's heading, but I figure it would be preferable to fix the immediate issue while that discussion takes place.

_Note_: Lightbox audits indicated several other issues that should be easy fixes, but I couldn't move on them as I was unable to find documentation for the pre-1.0 version of Gatsby the site is using. I'll make a couple issues for them.